### PR TITLE
promoting common metadata to global

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -47,6 +47,9 @@
     "globalMetadata": {
       "breadcrumb_path": "/azure/architecture/bread/toc.json",
       "brand": "azure",
+      "ms.author": "pnp",
+      "ms.service": "guidance",
+      "ms.topic": "article",
       "searchScope": [
         "Azure"
       ]


### PR DESCRIPTION
This metadata is the default for everything in the repository.
It can still be overwritten at the level of the individual file.
(More information [available internally](https://review.docs.microsoft.com/en-us/help/contribute/contribute-how-to-write-metadata))