### PR TITLE
Correct open/closed confusion in code comments on circuit-breaker half-open state

### DIFF
--- a/docs/patterns/circuit-breaker.md
+++ b/docs/patterns/circuit-breaker.md
@@ -222,9 +222,9 @@ Additionally, it uses a lock to prevent the circuit breaker from trying to perfo
             action();
 
             // If this action succeeds, reset the state and allow other operations.
-            // In reality, instead of immediately returning to the Open state, a counter
+            // In reality, instead of immediately returning to the Closed state, a counter
             // here would record the number of successful operations and return the
-            // circuit breaker to the Open state only after a specified number succeed.
+            // circuit breaker to the Closed state only after a specified number succeed.
             this.stateStore.Reset();
             return;
           }


### PR DESCRIPTION
The code commentary on recovery from `HalfOpen` state confuses the `Closed` state with `Open`.  (We see this mistake frequently when users comment on CircuitBreaker in the Polly project, as the polarity of a circuit-breaker is opposite to that of a gateway: open = _blocking_; closed = _permitting_).