### PR TITLE
retry doc - update outdated references

### DIFF
--- a/docs/patterns/retry.md
+++ b/docs/patterns/retry.md
@@ -48,9 +48,9 @@ The application should wrap all attempts to access a remote service in code that
 
 An application should log the details of faults and failing operations. This information is useful to operators. If a service is frequently unavailable or busy, it's often because the service has exhausted its resources. You can reduce the frequency of these faults by scaling out the service. For example, if a database service is continually overloaded, it might be beneficial to partition the database and spread the load across multiple servers.
 
-> The [Microsoft Entity Framework](https://docs.microsoft.com/ef/) provides facilities for retrying database operations. Additionally, [most Azure services and client SDKs include a retry mechanism](https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific).
+> [Microsoft Entity Framework](https://docs.microsoft.com/ef/) provides facilities for retrying database operations. Also, most Azure services and client SDKs include a retry mechanism. For more information, see [Retry guidance for specific services](https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific).
 
-## Issues and considerations
+## Issues and considerationsm
 
 You should consider the following points when deciding how to implement this pattern.
 

--- a/docs/patterns/retry.md
+++ b/docs/patterns/retry.md
@@ -48,7 +48,7 @@ The application should wrap all attempts to access a remote service in code that
 
 An application should log the details of faults and failing operations. This information is useful to operators. If a service is frequently unavailable or busy, it's often because the service has exhausted its resources. You can reduce the frequency of these faults by scaling out the service. For example, if a database service is continually overloaded, it might be beneficial to partition the database and spread the load across multiple servers.
 
-> Microsoft Azure provides extensive support for the Retry pattern. The patterns & practices [Transient Fault Handling Block](https://msdn.microsoft.com/library/hh680934.aspx) enables an application to handle transient faults in many Azure services using a range of retry strategies. The [Microsoft Entity Framework version 6](https://msdn.microsoft.com/en-us/data/dn456835.aspx) provides facilities for retrying database operations. Additionally, many of the Azure Service Bus and Azure Storage APIs implement retry logic transparently.
+> The [Microsoft Entity Framework](https://docs.microsoft.com/ef/) provides facilities for retrying database operations. Additionally, [most Azure services and client SDKs include a retry mechanism](https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific).
 
 ## Issues and considerations
 
@@ -172,5 +172,5 @@ private bool IsTransient(Exception ex)
 ## Related patterns and guidance
 
 - [Circuit Breaker pattern](circuit-breaker.md). The Retry pattern is useful for handling transient faults. If a failure is expected to be more long lasting, it might be more appropriate to implement the Circuit Breaker pattern. The Retry pattern can also be used in conjunction with a circuit breaker to provide a comprehensive approach to handling faults.
-- [Transient Fault Handling Application Block](https://msdn.microsoft.com/library/hh680934.aspx).
-- [Connection Resiliency / Retry Logic](https://msdn.microsoft.com/en-us/data/dn456835.aspx)
+- [Retry guidance for specific services](https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific)
+- [Connection Resiliency](https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency)


### PR DESCRIPTION
update references to EF and Transient Fault Handling Application Block outdated versions