### PR TITLE
Small error describing a GET request

### DIFF
--- a/docs/best-practices/api-design.md
+++ b/docs/best-practices/api-design.md
@@ -157,7 +157,7 @@ A PUT request is intended to modify an existing resource. If the specified resou
 ### Processing HTTP requests
 The data included by a client application in many HTTP requests, and the corresponding response messages from the web server, could be presented in a variety of formats (or media types). For example, the data that specifies the details for a customer or order could be provided as XML, JSON, or some other encoded and compressed format. A RESTful web API should support different media types as requested by the client application that submits a request.
 
-When a client application sends a request that returns data in the body of a message, it can specify the media types it can handle in the Accept header of the request. The following code illustrates an HTTP GET request that retrieves the details of customer 1 and requests the result to be returned as JSON (the client should still examine the media type of the data in the response to verify the format of the data returned):
+When a client application sends a request that returns data in the body of a message, it can specify the media types it can handle in the Accept header of the request. The following code illustrates an HTTP GET request that retrieves the details of order 2 and requests the result to be returned as JSON (the client should still examine the media type of the data in the response to verify the format of the data returned):
 
 ```HTTP
 GET http://adventure-works.com/orders/2 HTTP/1.1


### PR DESCRIPTION
The description incorrectly describes the GET request as retrieving customer 1, when it actually retrieves order 2.