### PR TITLE
Correct usage example for Polly retry

### DIFF
--- a/docs/best-practices/retry-service-specific.md
+++ b/docs/best-practices/retry-service-specific.md
@@ -454,20 +454,13 @@ public async static Task<SqlDataReader> ExecuteReaderWithRetryAsync(this SqlComm
 
 ```
 
-> [!NOTE]
-> This code is slightly modified from a sample located at the [Polly GitHub repo](https://github.com/App-vNext/Polly-Samples/blob/master/PollyTestClient/Samples/AsyncDemo02_WaitAndRetryNTimes.cs).
->
->
-
 This asynchronous extension method can be used as follows.
 
 ```csharp
 var sqlCommand = sqlConnection.CreateCommand();
 sqlCommand.CommandText = "[some query]";
 
-var retryPolicy =
-    RetryManager.Instance.GetRetryPolicy<SqlDatabaseTransientErrorDetectionStrategy>("alt sql");
-using (var reader = await sqlCommand.ExecuteReaderWithRetryAsync(retryPolicy))
+using (var reader = await sqlCommand.ExecuteReaderWithRetryAsync())
 {
     // Do something with the values
 }


### PR DESCRIPTION
+ Corrects the usage example for Polly, which was not brought into line with the Polly code as part of #80.  

+ Removes the note that Polly example is lightly modified from the Polly-Samples repo (it is not any more).