### PR TITLE
add list of Reserved Words

### DIFF
--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -173,3 +173,7 @@ It is not possible to modify the name of a storage account or container after it
 <!-- links -->
 
 [scaffold]: /azure/azure-resource-manager/resource-manager-subscription-governance
+
+
+
+add list of Reserved Words  


### PR DESCRIPTION
CRI 50012373 
We need to add a list of Reserved Words for Azure Resources - that can't be used by customers. That will avoid some cases opened with CSS to ask about why they can't use names like "loginstorage" or similar...

This list is maintained on src/frontdoor/Roles/Frontdoor.Data/Resources/WordFilterReservedSubstrings.txt
eg.

MICROSOFT
WINDOWS
OFFICE365
ONEDRIVE
BING
GROOVE
XBOX
HOLOLENS
CORTANA
DYNAMICS
MSDN
BIZTALK
BIZSPARK
VISUALSTUDIO
LOGIN
O365
DIRECTX
DOTNET
FOREFRONT
HYPERV
LYNC
OUTLOOK
SHAREPOINT