### PR TITLE
M16827: Possible incorrect term "read/write store"

### DIFF
--- a/docs/patterns/cqrs.md
+++ b/docs/patterns/cqrs.md
@@ -47,7 +47,7 @@ The query model for reading data and the update model for writing data can acces
 
 ![A CQRS architecture with separate read and write stores](./_images/command-and-query-responsibility-segregation-cqrs-separate-stores.png)
 
-The read store can be a read-only replica of the write store, or the read and write stores can have a different structure altogether. Using multiple read-only replicas of the read store can greatly increase query performance and application UI responsiveness, especially in distributed scenarios where read-only replicas are located close to the application instances. Some database systems (SQL Server) provide additional features such as failover replicas to maximize availability.
+The read store can be a read-only replica of the write store, or the read and write stores can have a different structure altogether. Using multiple read-only replicas of the write store can greatly increase query performance and application UI responsiveness, especially in distributed scenarios where read-only replicas are located close to the application instances. Some database systems (SQL Server) provide additional features such as failover replicas to maximize availability.
 
 Separation of the read and write stores also allows each to be scaled appropriately to match the load. For example, read stores typically encounter a much higher load than write stores.
 


### PR DESCRIPTION
Hello, @dragon119, 

Translator has reported possible source content issue. Judging from the previous segment, "read-only replicas of the read store" may be a misdescription of "read-only replicas of the write store".

Please, help to check my proposed file change into the article and help to merge if you agree with fix. If not, please, let me know either if you would like me to fix it in another way within this PR, if you prefer to fix it in another PR, or if I should close this PR as by-design. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.