### PR TITLE
naming conventions: consistent hyphenated words

### DIFF
--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -72,29 +72,29 @@ In general, avoid having any special characters (`-` or `_`) as the first or las
 
 | Category | Service or Entity | Scope | Length | Casing | Valid Characters | Suggested Pattern | Example |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Resource Group |Resource Group |Global |1-64 |Case-insensitive |Alphanumeric, underscore, parentheses, hyphen, an period (except at end) |`<service short name>-<environment>-rg` |`profx-prod-rg` |
-| Resource Group |Availability Set |Resource Group |1-80 |Case-insensitive |Alphanumeric, underscore, and hyphen |`<service-short-name>-<context>-as` |`profx-sql-as` |
-| General |Tag |Associated Entity |512 (name), 256 (value) |Case-insensitive |Alphanumeric |`"key" : "value"` |`"department" : "Central IT"` |
-| Compute |Virtual Machine |Resource Group |1-15 (Windows), 1-64 (Linux) |Case-insensitive |Alphanumeric, underscore, and hyphen |`<name>-<role>-vm<number>` |`profx-sql-vm1` |
-| Compute |Function App | Global |1-60 |Case-insensitive |Alphanumeric and hyphen |`<name>-func` |`calcprofit-func` |
+| Resource Group |Resource Group |Global |1-64 |Case insensitive |Alphanumeric, underscore, parentheses, hyphen, an period (except at end) |`<service short name>-<environment>-rg` |`profx-prod-rg` |
+| Resource Group |Availability Set |Resource Group |1-80 |Case insensitive |Alphanumeric, underscore, and hyphen |`<service-short-name>-<context>-as` |`profx-sql-as` |
+| General |Tag |Associated Entity |512 (name), 256 (value) |Case insensitive |Alphanumeric |`"key" : "value"` |`"department" : "Central IT"` |
+| Compute |Virtual Machine |Resource Group |1-15 (Windows), 1-64 (Linux) |Case insensitive |Alphanumeric, underscore, and hyphen |`<name>-<role>-vm<number>` |`profx-sql-vm1` |
+| Compute |Function App | Global |1-60 |Case insensitive |Alphanumeric and hyphen |`<name>-func` |`calcprofit-func` |
 | Storage |Storage account name (data) |Global |3-24 |Lowercase |Alphanumeric |`<globally unique name><number>` (use a function to calculate a unique guid for naming storage accounts) |`profxdata001` |
 | Storage |Storage account name (disks) |Global |3-24 |Lowercase |Alphanumeric |`<vm name without dashes>st<number>` |`profxsql001st0` |
 | Storage | Container name |Storage account |3-63 |Lowercase |Alphanumeric and dash |`<context>` |`logs` |
-| Storage |Blob name | Container |1-1024 |Case-sensitive |Any URL char |`<variable based on blob usage>` |`<variable based on blob usage>` |
+| Storage |Blob name | Container |1-1024 |Case sensitive |Any URL char |`<variable based on blob usage>` |`<variable based on blob usage>` |
 | Storage |Queue name |Storage account |3-63 |Lowercase |Alphanumeric and dash |`<service short name>-<context>-<num>` |`awesomeservice-messages-001` |
-| Storage |Table name | Storage account |3-63 |Case-insensitive |Alphanumeric |`<service short name><context>` |`awesomeservicelogs` |
+| Storage |Table name | Storage account |3-63 |Case insensitive |Alphanumeric |`<service short name><context>` |`awesomeservicelogs` |
 | Storage |File name | Storage account |3-63 |Lowercase | Alphanumeric |`<variable based on blob usage>` |`<variable based on blob usage>` |
 | Storage |Data Lake Store | Global |3-24 |Lowercase | Alphanumeric |`<name>-dtl` |`telemetry-dtl` |
-| Networking |Virtual Network (VNet) |Resource Group |2-64 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<service short name>-vnet` |`profx-vnet` |
-| Networking |Subnet |Parent VNet |2-80 |Case-insensitive |Alphanumeric, underscore, dash, and period |`<descriptive context>` |`web` |
-| Networking |Network Interface |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<vmname>-nic<num>` |`profx-sql1-nic1` |
-| Networking |Network Security Group |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<service short name>-<context>-nsg` |`profx-app-nsg` |
-| Networking |Network Security Group Rule |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<descriptive context>` |`sql-allow` |
-| Networking |Public IP Address |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<vm or service name>-pip` |`profx-sql1-pip` |
-| Networking |Load Balancer |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<service or role>-lb` |`profx-lb` |
-| Networking |Load Balanced Rules Config |Load Balancer |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<descriptive context>` |`http` |
-| Networking |Azure Application Gateway |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<service or role>-agw` |`profx-agw` |
-| Networking |Traffic Manager Profile |Resource Group |1-63 |Case-insensitive |Alphanumeric, dash, and period |`<descriptive context>` |`app1` |
+| Networking |Virtual Network (VNet) |Resource Group |2-64 |Case insensitive |Alphanumeric, dash, underscore, and period |`<service short name>-vnet` |`profx-vnet` |
+| Networking |Subnet |Parent VNet |2-80 |Case insensitive |Alphanumeric, underscore, dash, and period |`<descriptive context>` |`web` |
+| Networking |Network Interface |Resource Group |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<vmname>-nic<num>` |`profx-sql1-nic1` |
+| Networking |Network Security Group |Resource Group |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<service short name>-<context>-nsg` |`profx-app-nsg` |
+| Networking |Network Security Group Rule |Resource Group |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<descriptive context>` |`sql-allow` |
+| Networking |Public IP Address |Resource Group |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<vm or service name>-pip` |`profx-sql1-pip` |
+| Networking |Load Balancer |Resource Group |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<service or role>-lb` |`profx-lb` |
+| Networking |Load Balanced Rules Config |Load Balancer |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<descriptive context>` |`http` |
+| Networking |Azure Application Gateway |Resource Group |1-80 |Case insensitive |Alphanumeric, dash, underscore, and period |`<service or role>-agw` |`profx-agw` |
+| Networking |Traffic Manager Profile |Resource Group |1-63 |Case insensitive |Alphanumeric, dash, and period |`<descriptive context>` |`app1` |
 
 > [!NOTE]
 > Virtual machines in Azure have two distinct names: virtual machine name, and host name. When you create a VM in the portal, the same name is used for both the host name, and the virtual machine resource name. The restrictions above are for the host name. The actual resource name can have up to 64 characters.

--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -72,19 +72,19 @@ In general, avoid having any special characters (`-` or `_`) as the first or las
 
 | Category | Service or Entity | Scope | Length | Casing | Valid Characters | Suggested Pattern | Example |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Resource Group |Resource Group |Global |1-64 |Case insensitive |Alphanumeric, underscore, parentheses, hyphen, an period (except at end) |`<service short name>-<environment>-rg` |`profx-prod-rg` |
-| Resource Group |Availability Set |Resource Group |1-80 |Case insensitive |Alphanumeric, underscore, and hyphen |`<service-short-name>-<context>-as` |`profx-sql-as` |
-| General |Tag |Associated Entity |512 (name), 256 (value) |Case insensitive |Alphanumeric |`"key" : "value"` |`"department" : "Central IT"` |
-| Compute |Virtual Machine |Resource Group |1-15 (Windows), 1-64 (Linux) |Case insensitive |Alphanumeric, underscore, and hyphen |`<name>-<role>-vm<number>` |`profx-sql-vm1` |
-| Compute |Function App | Global |1-60 |Case insensitive |Alphanumeric and hyphen |`<name>-func` |`calcprofit-func` |
-| Storage |Storage account name (data) |Global |3-24 |Lower case |Alphanumeric |`<globally unique name><number>` (use a function to calculate a unique guid for naming storage accounts) |`profxdata001` |
-| Storage |Storage account name (disks) |Global |3-24 |Lower case |Alphanumeric |`<vm name without dashes>st<number>` |`profxsql001st0` |
-| Storage | Container name |Storage account |3-63 |Lower case |Alphanumeric and dash |`<context>` |`logs` |
-| Storage |Blob name | Container |1-1024 |Case sensitive |Any URL char |`<variable based on blob usage>` |`<variable based on blob usage>` |
-| Storage |Queue name |Storage account |3-63 |Lower case |Alphanumeric and dash |`<service short name>-<context>-<num>` |`awesomeservice-messages-001` |
-| Storage |Table name | Storage account |3-63 |Case insensitive |Alphanumeric |`<service short name><context>` |`awesomeservicelogs` |
-| Storage |File name | Storage account |3-63 |Lower case | Alphanumeric |`<variable based on blob usage>` |`<variable based on blob usage>` |
-| Storage |Data Lake Store | Global |3-24 |Lower case | Alphanumeric |`<name>-dtl` |`telemetry-dtl` |
+| Resource Group |Resource Group |Global |1-64 |Case-insensitive |Alphanumeric, underscore, parentheses, hyphen, an period (except at end) |`<service short name>-<environment>-rg` |`profx-prod-rg` |
+| Resource Group |Availability Set |Resource Group |1-80 |Case-insensitive |Alphanumeric, underscore, and hyphen |`<service-short-name>-<context>-as` |`profx-sql-as` |
+| General |Tag |Associated Entity |512 (name), 256 (value) |Case-insensitive |Alphanumeric |`"key" : "value"` |`"department" : "Central IT"` |
+| Compute |Virtual Machine |Resource Group |1-15 (Windows), 1-64 (Linux) |Case-insensitive |Alphanumeric, underscore, and hyphen |`<name>-<role>-vm<number>` |`profx-sql-vm1` |
+| Compute |Function App | Global |1-60 |Case-insensitive |Alphanumeric and hyphen |`<name>-func` |`calcprofit-func` |
+| Storage |Storage account name (data) |Global |3-24 |Lowercase |Alphanumeric |`<globally unique name><number>` (use a function to calculate a unique guid for naming storage accounts) |`profxdata001` |
+| Storage |Storage account name (disks) |Global |3-24 |Lowercase |Alphanumeric |`<vm name without dashes>st<number>` |`profxsql001st0` |
+| Storage | Container name |Storage account |3-63 |Lowercase |Alphanumeric and dash |`<context>` |`logs` |
+| Storage |Blob name | Container |1-1024 |Case-sensitive |Any URL char |`<variable based on blob usage>` |`<variable based on blob usage>` |
+| Storage |Queue name |Storage account |3-63 |Lowercase |Alphanumeric and dash |`<service short name>-<context>-<num>` |`awesomeservice-messages-001` |
+| Storage |Table name | Storage account |3-63 |Case-insensitive |Alphanumeric |`<service short name><context>` |`awesomeservicelogs` |
+| Storage |File name | Storage account |3-63 |Lowercase | Alphanumeric |`<variable based on blob usage>` |`<variable based on blob usage>` |
+| Storage |Data Lake Store | Global |3-24 |Lowercase | Alphanumeric |`<name>-dtl` |`telemetry-dtl` |
 | Networking |Virtual Network (VNet) |Resource Group |2-64 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<service short name>-vnet` |`profx-vnet` |
 | Networking |Subnet |Parent VNet |2-80 |Case-insensitive |Alphanumeric, underscore, dash, and period |`<descriptive context>` |`web` |
 | Networking |Network Interface |Resource Group |1-80 |Case-insensitive |Alphanumeric, dash, underscore, and period |`<vmname>-nic<num>` |`profx-sql1-nic1` |


### PR DESCRIPTION
For "Naming Rules and Restrictions"-table, both hyphenated and non-hyphenated form is used for some values (such as "Case-insensitive" and "Case insensitive"). This PR is suggestion for consistent names.