### PR TITLE
naming conventions: change 3-letter suffix for Data Lake Store from 'dtl' to 'dls'

### DIFF
--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -99,7 +99,7 @@ In general, avoid having any special characters (`-` or `_`) as the first or las
 |Queue name |Storage account |3-63 |Lowercase |Alphanumeric and dash |`<service short name>-<context>-<num>` |`awesomeservice-messages-001` |
 |Table name | Storage account |3-63 |Case insensitive |Alphanumeric |`<service short name><context>` |`awesomeservicelogs` |
 |File name | Storage account |3-63 |Lowercase | Alphanumeric |`<variable based on blob usage>` |`<variable based on blob usage>` |
-|Data Lake Store | Global |3-24 |Lowercase | Alphanumeric |`<name>-dtl` |`telemetry-dtl` |
+|Data Lake Store | Global |3-24 |Lowercase | Alphanumeric |`<name>-dls` |`telemetry-dls` |
 
 ### Networking
 


### PR DESCRIPTION
Dear all, could you please consider if it make sense to change 3-letter suffix for Data Lake Store from 'dtl' to 'dls'. The justification is that other tools already use the 'dls' abbreviation (such as Azure CLI ). Also 'dls' seem to be appropriate for the resoure type 'Microsoft.**D**ata**L**ake**S**tore'. 
Ref. [5fe63d8](https://github.com/mspnp/architecture-center/commit/5fe63d855edc8d835815d6b55b2f04bd9064674c#diff-3dfaf96e20870714a40627c031d9f695R90). Thanks (and sorry about the messy PRs).
FYI: 'dtl' is widely used abbreviation for DevTest Labs, even some templates in azure-quickstart-templates repo use it (even though 'lab' perhaps is better abbreviation for DevTest Labs).