### PR TITLE
Remove "highly normalized"

### DIFF
--- a/docs/data-guide/concepts/semantic-modeling.md
+++ b/docs/data-guide/concepts/semantic-modeling.md
@@ -42,7 +42,6 @@ Semantic modeling and analytical processing tends to have the following traits:
 
 | Requirement | Description |
 | --- | --- |
-| Normalization | Highly normalized |
 | Schema | Schema on write, strongly enforced|
 | Uses Transactions | No |
 | Locking Strategy | None |


### PR DESCRIPTION
This shouldn't have been left in there, so I'm correcting the mistake. Rather than saying "typically denormalized", or "low normalization", I think it's best to remove altogether, as it's not an important basis of comparison against a relational data model.

There are not specifications, per se, that dictate the level of normalization that should be applied to semantic models. While it's true that oftentimes some denormalization occurs when creating a semantic model, if the model is meant to be consumed by users who would not have knowledge of the underlying data structure and the importance of some relationships over others. But denormalization is not a prerequisite for a semantic model, because you can still express relationships. Though the goal is less about storing data efficiently (like through normalization) and more about expressing the logical model of the data. In either case, being highly normalized is certainly not an attribute of a semantic model.