### PR TITLE
/en-us/ hardcord

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -152,7 +152,7 @@
   - name: Azure Roadmap
     href: https://azure.microsoft.com/roadmap/
   - name: Microsoft Trust Center for Azure
-    href: https://www.microsoft.com/en-us/trustcenter/cloudservices/azure
+    href: https://www.microsoft.com//trustcenter/cloudservices/azure
   - name: Icons and diagrams
     href: resources/diagrams.md
   - name: Calendar of Azure updates


### PR DESCRIPTION
Please remove /en-us/ for non_en-us local redirection purpose.