### PR TITLE
Fix 'API Design' code sample

### DIFF
--- a/docs/best-practices/api-design.md
+++ b/docs/best-practices/api-design.md
@@ -243,7 +243,7 @@ Content-Type: application/json
 
 {
     "status":"In progress",
-    "link": { "rel":"cancel", "method":"delete", "href":"/api/status/12345"
+    "link": { "rel":"cancel", "method":"delete", "href":"/api/status/12345" }
 }
 ```
 


### PR DESCRIPTION
Add missing curly brace for `best-practices/api-design`.