### PR TITLE
Resource Groups should be introduced before Resource Tags

### DIFF
--- a/docs/cloud-adoption-guide/subscription-governance.md
+++ b/docs/cloud-adoption-guide/subscription-governance.md
@@ -136,6 +136,21 @@ To view how your environment is functioning, you need to audit user activity. Mo
 
 Activity logs from Resource Manager deployments enable you to determine the **operations** that took place and who performed them. Activity logs can be collected and aggregated using tools like Log Analytics.
 
+
+## Resource group
+Resource Manager enables you to put resources into meaningful groups for management, billing, or natural affinity. As mentioned earlier, Azure has two deployment models. In the earlier Classic model, the basic unit of management was the subscription. It was difficult to break down resources within a subscription, which led to the creation of large numbers of subscriptions. With the Resource Manager model, we saw the introduction of resource groups. Resource groups are containers of resources that have a common lifecycle or share an attribute such as "all SQL servers" or "Application A".
+
+Resource groups cannot be contained within each other and resources can only belong to one resource group. You can apply certain actions on all resources in a resource group. For example, deleting a resource group removes all resources within the resource group. Typically, you place an entire application or related system in the same resource group. For example, a three-tier application called Contoso Web Application would contain the web server, application server and SQL server in the same resource group.
+
+> [!TIP]
+> How you organize your resource groups may vary from "Traditional IT" workloads to "Agile IT" workloads:
+> 
+> * "Traditional IT" workloads are most commonly grouped by items within the same lifecycle, such as an application. Grouping by application allows for individual application management.
+> * "Agile IT" workloads tend to focus on external customer-facing cloud applications. The resource groups should reflect the layers of deployment (such as Web Tier, App Tier) and management.
+> 
+> Understanding your workload helps you develop a resource group strategy.
+
+
 ## Resource tags
 As users in your organization add resources to the subscription, it becomes increasingly important to associate resources with the appropriate department, customer, and environment. You can attach metadata to resources through [tags](/azure/azure-resource-manager/resource-group-using-tags). You use tags to provide information about the resource or the owner. Tags enable you to not only aggregate and group resources in various ways, but use that data for the purposes of chargeback. You can tag resources with up to 15 key:value pairs. 
 
@@ -162,18 +177,7 @@ For more examples of tags, see [Recommended naming conventions for Azure resourc
 > 
 > This tagging strategy identifies across your subscriptions what metadata is needed for the business, finance, security, risk management, and overall management of the environment. 
 
-## Resource group
-Resource Manager enables you to put resources into meaningful groups for management, billing, or natural affinity. As mentioned earlier, Azure has two deployment models. In the earlier Classic model, the basic unit of management was the subscription. It was difficult to break down resources within a subscription, which led to the creation of large numbers of subscriptions. With the Resource Manager model, we saw the introduction of resource groups. Resource groups are containers of resources that have a common lifecycle or share an attribute such as "all SQL servers" or "Application A".
 
-Resource groups cannot be contained within each other and resources can only belong to one resource group. You can apply certain actions on all resources in a resource group. For example, deleting a resource group removes all resources within the resource group. Typically, you place an entire application or related system in the same resource group. For example, a three-tier application called Contoso Web Application would contain the web server, application server and SQL server in the same resource group.
-
-> [!TIP]
-> How you organize your resource groups may vary from "Traditional IT" workloads to "Agile IT" workloads:
-> 
-> * "Traditional IT" workloads are most commonly grouped by items within the same lifecycle, such as an application. Grouping by application allows for individual application management.
-> * "Agile IT" workloads tend to focus on external customer-facing cloud applications. The resource groups should reflect the layers of deployment (such as Web Tier, App Tier) and management.
-> 
-> Understanding your workload helps you develop a resource group strategy.
 
 ## Role-based access control
 You probably are asking yourself "who should have access to resources?" and "how do I control this access?" Allowing or disallowing access to the Azure portal, and controlling access to resources in the portal is crucial. 


### PR DESCRIPTION
Resource Groups should be introduced before Resource Tags, since it makes sense to refer to the hierarchy resource > rg when talking about tags.