### PR TITLE
M29206: "Microsoft Enterprise Agreement" link doesn't work

### DIFF
--- a/docs/cloud-adoption-guide/adoption-intro/governance-how-to.md
+++ b/docs/cloud-adoption-guide/adoption-intro/governance-how-to.md
@@ -20,6 +20,7 @@ Before we begin designing our governance model, it's important to understand how
 
 > [!NOTE]
 > If your organization has an existing [Microsoft Enterprise Agreement](https://www.microsoft.com/licensing/licensing-programs/enterprise.aspx) that does not include Azure, Azure can be added by making an upfront monetary commitment. See [licensing Azure for the enterprise](https://azure.microsoft.com/pricing/enterprise-agreement/) for more information. 
+<!-- Previous "Microsoft Enterprise Agreement" link doesn't work -->
 
 When Azure added to your organization's Enterprise Agreement, your organization was prompted to create an **Azure account**. During the account creation process, an **Azure account owner** was created, as well as an Azure Active Directory (Azure AD) tenant with a **global administrator** account. An Azure AD tenant is a logical construct that represents a secure, dedicated instance of Azure AD.
 


### PR DESCRIPTION
Hello, @petertay,  
Translator has reported possible source content issue. 
"Microsoft Enterprise Agreement" link doesn't work.

Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.