### PR TITLE
1387770: Fixed the broken "Microsoft Systems Center" link.

### DIFF
--- a/docs/reference-architectures/identity/adds-extend-domain.md
+++ b/docs/reference-architectures/identity/adds-extend-domain.md
@@ -173,7 +173,7 @@ After deployment completes, you can test conectivity from the simulated on-premi
 [capacity-planning-for-adds]: https://social.technet.microsoft.com/wiki/contents/articles/14355.capacity-planning-for-active-directory-domain-services.aspx
 [considerations]: ./considerations.md
 [GitHub]: https://github.com/mspnp/identity-reference-architectures/tree/master/adds-extend-domain
-[microsoft_systems_center]: https://www.microsoft.com/server-cloud/products/system-center-2016/
+[microsoft_systems_center]: https://www.microsoft.com/download/details.aspx?id=50013
 [monitoring_ad]: https://msdn.microsoft.com/library/bb727046.aspx
 [security-considerations]: #security-considerations
 [set-a-static-ip-address]: /azure/virtual-network/virtual-networks-static-private-ip-arm-pportal


### PR DESCRIPTION
For [Task 1387770: Assist w/ fixing broken links in Azure-docs-pr](https://mseng.visualstudio.com/TechnicalContent/_workitems/edit/1387770).

In our azure-docs-pr broken link report, the URL https://docs.microsoft.com/en-us/azure/guidance/guidance-identity-adds-extend-domain contained a broken link, but this URL redirected to https://docs.microsoft.com/azure/architecture/reference-architectures/identity/adds-extend-domain, which belongs to your repo.

I changed the broken **Microsoft Systems Center** link to go to the download page for **Microsoft System Center 2016 Management Pack for Microsoft Azure**.