### PR TITLE
M32994: Typo: loading or operational data stores

### DIFF
--- a/docs/example-scenario/data/hybrid-etl-with-adf.md
+++ b/docs/example-scenario/data/hybrid-etl-with-adf.md
@@ -25,7 +25,7 @@ Several potential on-premises use cases are listed below:
 * Loading network router logs to a database for analysis.
 * Preparing human resources employment data for analytical reporting.
 * Loading product and sales data into a data warehouse for sales forecasting.
-* Automating loading or operating data stores or data warehouses for finance and accounting.
+* Automating loading of operational data stores or data warehouses for finance and accounting.
 
 ## Architecture
 


### PR DESCRIPTION
Hi @MikeWasson,
I have made change here: https://github.com/mspnp/architecture-center/pull/1009
But I accidentally made a mistake. The suggestion is actually like this "Automating loading of operational data stores or data warehouses for finance and accounting."
If you agree could you please merge this one.
Thanks in advance