### PR TITLE
Indicate that patterns are cloud agnostic

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Design Patterns
-description: Cloud Design Patterns for Microsoft Azure
+description: Cloud Design Patterns for building reliable, scalable, secure applications in the cloud
 keywords: Azure
 ms.date: 12/10/2018
 ---


### PR DESCRIPTION
This commit updates the description to remove the suggestion that these patterns are specific to Azure. This description field is used when links to this document are unfurled by applications like Slack.