### PR TITLE
outdated information on per minute billing

### DIFF
--- a/docs/aws-professional/index.md
+++ b/docs/aws-professional/index.md
@@ -248,7 +248,7 @@ similar way, there are differences in the RAM, CPU, and storage capabilities.
 -   [Sizes for virtual machines in Azure
     (Linux)](https://azure.microsoft.com/documentation/articles/virtual-machines-linux-sizes/)
 
-Unlike AWS' per second billing, Azure on-demand VMs are billed by the minute.
+Similar to AWS' per second billing, Azure on-demand VMs are billed per second.
 
 #### EBS and Azure Storage for VM disks
 


### PR DESCRIPTION
we have multiple sites on Azure mentioning per minute (legacy policy) and per second. I believe that we have annouced that all our VMs are charged per second, round down to the nearest minute