### PR TITLE
Fixing broken link to retry.md

### DIFF
--- a/docs/patterns/circuit-breaker.md
+++ b/docs/patterns/circuit-breaker.md
@@ -17,7 +17,7 @@ Handle faults that might take a variable amount of time to recover from, when co
 
 ## Context and problem
 
-In a distributed environment, calls to remote resources and services can fail due to transient faults, such as slow network connections, timeouts, or the resources being overcommitted or temporarily unavailable. These faults typically correct themselves after a short period of time, and a robust cloud application should be prepared to handle them by using a strategy such as the [Retry pattern][retry-pattern].
+In a distributed environment, calls to remote resources and services can fail due to transient faults, such as slow network connections, timeouts, or the resources being overcommitted or temporarily unavailable. These faults typically correct themselves after a short period of time, and a robust cloud application should be prepared to handle them by using a strategy such as the [Retry pattern](./retry.md).
 
 However, there can also be situations where faults are due to unanticipated events, and that might take much longer to fix. These faults can range in severity from a partial loss of connectivity to the complete failure of a service. In these situations it might be pointless for an application to continually retry an operation that is unlikely to succeed, and instead the application should quickly accept that the operation has failed and handle this failure accordingly.
 


### PR DESCRIPTION
There was a broken link in the Circuit Breaker pattern page to the retry pattern.  This should fix it.