### PR TITLE
C63784: Removing brackets "<>"

### DIFF
--- a/docs/reference-architectures/data/stream-processing-stream-analytics.md
+++ b/docs/reference-architectures/data/stream-processing-stream-analytics.md
@@ -42,7 +42,7 @@ The architecture consists of the following components.
 
 To simulate a data source, this reference architecture uses the [New York City Taxi Data](https://uofi.app.box.com/v/NYCtaxidata/folder/2332218797) dataset<sup>[[1]](#note1)</sup>. This dataset contains data about taxi trips in New York City over a 4-year period (2010 &ndash; 2013). It contains two types of record: Ride data and fare data. Ride data includes trip duration, trip distance, and pickup and dropoff location. Fare data includes fare, tax, and tip amounts. Common fields in both record types include medallion number, hack license, and vendor ID. Together these three fields uniquely identify a taxi plus a driver. The data is stored in CSV format.
 
-[1] <span id="note1">Donovan, Brian; Work, Dan (2016): New York City Taxi Trip Data (2010-2013). University of Illinois at Urbana-Champaign. <https://doi.org/10.13012/J8PN93H8>
+[1] <span id="note1">Donovan, Brian; Work, Dan (2016): New York City Taxi Trip Data (2010-2013). University of Illinois at Urbana-Champaign. https://doi.org/10.13012/J8PN93H8
 
 <!-- markdownlint-enable MD033 -->
 


### PR DESCRIPTION
Hello @MikeWasson,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description of the source issue:   link syntax <link> is breaking sxs structure, therefore, preventing content to be localized. Kindly consider removing them.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.