### PR TITLE
Correct the day-2 operations guide linke

### DIFF
--- a/docs/reference-architectures/containers/aks-start-here.md
+++ b/docs/reference-architectures/containers/aks-start-here.md
@@ -86,7 +86,7 @@ See [Best Practices for Cluster Operations](/azure/aks/best-practices) and [Best
 Getting your workload deployed on AKS is a great milestone and this is when [day-2 operations](https://dzone.com/articles/defining-day-2-operations) are going to be top-of-mind. **Microsoft's AKS Day 2 Operations Guide** was built for your ease of reference. This will help ensure you are ready to meet the demands of your customers and ensure you are prepared for break-fix situations via optimized triage processes.
 
 > [!div class="nextstepaction"]
-> [Microsoft's AKS Day 2 Operations Guide](../../operator-guides/aks/aks-triage-practices.md)
+> [Microsoft's AKS Day 2 Operations Guide](../../operator-guides/aks/day-2-operations-guide.md)
 
 ## Stay current with AKS
 


### PR DESCRIPTION
The current link sends people to the triage page, which is a sub topic under the overall day 2 operation guide.