### PR TITLE
Typo "respose"→” response”

### DIFF
--- a/docs/best-practices/api-design.md
+++ b/docs/best-practices/api-design.md
@@ -183,7 +183,7 @@ If the server cannot match any of the media type(s) listed, it should return HTT
 
 A successful GET method typically returns HTTP status code 200 (OK). If the resource cannot be found, the method should return 404 (Not Found).
 
-If the request was fulfilled but there is no respose body included in the HTTP response, then it should return HTTP status code 204 (No Content); for example, a search operation yielding no matches might be implemented with this behavior.
+If the request was fulfilled but there is no response body included in the HTTP response, then it should return HTTP status code 204 (No Content); for example, a search operation yielding no matches might be implemented with this behavior.
 
 ### POST methods
 


### PR DESCRIPTION
Adjust typo.

"If the request was fulfilled but there is no **respose** body included in the HTTP response, " 
to
"If the request was fulfilled but there is no **response** body included in the HTTP response, " 
